### PR TITLE
Bug fix: index.org file matching

### DIFF
--- a/src/com/matburt/mobileorg/SDCardSynchronizer.java
+++ b/src/com/matburt/mobileorg/SDCardSynchronizer.java
@@ -194,7 +194,7 @@ public class SDCardSynchronizer implements Synchronizer
 
     //NOTE: This is a common method and needs to be generalized
     private HashMap<String, String> getOrgFilesFromMaster(String master) {
-        Pattern getOrgFiles = Pattern.compile("\\[file:(.*?\\.(org|pgp|gpg|enc))\\]\\[(.*?)\\]\\]");
+        Pattern getOrgFiles = Pattern.compile("\\[file:(.*?\\.(?:org|pgp|gpg|enc))\\]\\[(.*?)\\]\\]");
         Matcher m = getOrgFiles.matcher(master);
         HashMap<String, String> allOrgFiles = new HashMap<String, String>();
         while (m.find()) {

--- a/src/com/matburt/mobileorg/WebDAVSynchronizer.java
+++ b/src/com/matburt/mobileorg/WebDAVSynchronizer.java
@@ -269,7 +269,7 @@ public class WebDAVSynchronizer implements Synchronizer
     }
 
     private HashMap<String, String> getOrgFilesFromMaster(String master) {
-        Pattern getOrgFiles = Pattern.compile("\\[file:(.*?\\.(org|pgp|gpg|enc))\\]\\[(.*?)\\]\\]");
+        Pattern getOrgFiles = Pattern.compile("\\[file:(.*?\\.(?:org|pgp|gpg|enc))\\]\\[(.*?)\\]\\]");
         Matcher m = getOrgFiles.matcher(master);
         HashMap<String, String> allOrgFiles = new HashMap<String, String>();
         while (m.find()) {


### PR DESCRIPTION
The introduction of encrypted file extensions (matburt/mobileorg-android@4288fa2482ef561eddaa61b6ca9b25d44c577462) introduced a subtle bug that causes multiple org-files in index.org to be ignored when syncing. 

Adding the capture group for file-extensions (org|pgp|...) causes the extension to be captured in "group(2)" instead of the name, which causes files with identical extensions to be overwritten when inserted into the HashMap. File-extension matching should use a non-capturing group instead (?:org|pgp|...)
