### PR TITLE
Fix webdav encoding

### DIFF
--- a/src/com/matburt/mobileorg/WebDAVSynchronizer.java
+++ b/src/com/matburt/mobileorg/WebDAVSynchronizer.java
@@ -355,7 +355,7 @@ public class WebDAVSynchronizer implements Synchronizer
                            String content) throws NotFoundException, ReportableError {
         try {
             HttpPut httpPut = new HttpPut(url);
-            httpPut.setEntity(new StringEntity(content));
+            httpPut.setEntity(new StringEntity(content, "UTF-8"));
             HttpResponse response = httpClient.execute(httpPut);
             httpClient.getConnectionManager().shutdown();
         }


### PR DESCRIPTION
It is necessary to specify UTF-8 encoding explicitly for StringEntity objects used for transmitting texts including characters other than 7-bit ASCII.  This setting would be helpful especially for users using locales using multi-byte encoding, e.g., Chinese, Japanese, and Korean.  UTF-8 encoding is designed backward-compatible to ASCII, which does not affect ASCII-only texts.
