### PR TITLE
Org entries seem to randomly accumulate tags

### DIFF
--- a/src/com/matburt/mobileorg/MobileOrgActivity.java
+++ b/src/com/matburt/mobileorg/MobileOrgActivity.java
@@ -155,6 +155,7 @@ public class MobileOrgActivity extends ListActivity
                                 this.thisNode.subNodes.get(position).schedule) + " ";
             }
 
+            tagsLayout.removeAllViews();
             for (String tag : this.thisNode.subNodes.get(position).tags) {
 				TextView tagView = new TextView(this.context);
 				tagView.setText(tag);


### PR DESCRIPTION
Hello, I'm new to mobileorg-android (and in fact, to android development and github in general), but I thought that this minor patch would be useful.  Without it, my entries seem to randomly accumulate tags.  Perhaps there is a way to simply keep the old tags without destroying and recreating these labels, but I didn't quite figure that out.
