### PR TITLE
Fixed "View as document" in OrgContextMenu and ViewNodeDetailsActivity. 

### DIFF
--- a/src/com/matburt/mobileorg/Capture/ViewNodeDetailsActivity.java
+++ b/src/com/matburt/mobileorg/Capture/ViewNodeDetailsActivity.java
@@ -108,7 +108,8 @@ public class ViewNodeDetailsActivity extends Activity implements OnClickListener
 	public void onClick(View v) {
 		if (v.equals(mViewAsDocument)) {
 			Intent intent = new Intent(this, SimpleTextDisplay.class);
-			intent.putExtra("txtValue", mNode.nodePayload);
+			String txtValue = mNode.nodeTitle + "\n\n" + mNode.nodePayload;
+			intent.putExtra("txtValue", txtValue );
 			this.startActivity(intent);
 		}
 		if (v.equals(mBody)) {

--- a/src/com/matburt/mobileorg/OrgContextMenu.java
+++ b/src/com/matburt/mobileorg/OrgContextMenu.java
@@ -57,7 +57,8 @@ public class OrgContextMenu extends Activity implements OnClickListener
         if (v == this.docButton) {
             textIntent.setClass(this,
                     SimpleTextDisplay.class);
-            textIntent.putExtra("txtValue", thisNode.nodePayload);
+			String txtValue = thisNode.nodeTitle + "\n\n" + thisNode.nodePayload;
+			textIntent.putExtra("txtValue", txtValue );
             textIntent.putExtra("nodeTitle", thisNode.nodeName);
         }
         else if (v == this.docEditButton) {


### PR DESCRIPTION
 Both node name and payload are now displayed.

https://github.com/matburt/mobileorg-android/issues/94
