### PR TITLE
Keeps the position in the list when navigating up the tree of nodes

### DIFF
--- a/src/com/matburt/mobileorg/MobileOrgActivity.java
+++ b/src/com/matburt/mobileorg/MobileOrgActivity.java
@@ -1,5 +1,13 @@
 package com.matburt.mobileorg;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.StringReader;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+
 import android.app.Activity;
 import android.app.ListActivity;
 import android.app.ProgressDialog;
@@ -12,8 +20,18 @@ import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.*;
-import android.widget.*;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
 import com.matburt.mobileorg.Capture.Capture;
 import com.matburt.mobileorg.Capture.ViewNodeDetailsActivity;
 import com.matburt.mobileorg.Error.ErrorReporter;
@@ -26,14 +44,6 @@ import com.matburt.mobileorg.Synchronizers.DropboxSynchronizer;
 import com.matburt.mobileorg.Synchronizers.SDCardSynchronizer;
 import com.matburt.mobileorg.Synchronizers.Synchronizer;
 import com.matburt.mobileorg.Synchronizers.WebDAVSynchronizer;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.StringReader;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 
 public class MobileOrgActivity extends ListActivity
 {
@@ -223,6 +233,7 @@ public class MobileOrgActivity extends ListActivity
     };
     
     protected ArrayList<Integer> mNodePath;
+	private int displayIndex;
 
     @Override
     public void onCreate(Bundle savedInstanceState)
@@ -313,6 +324,7 @@ public class MobileOrgActivity extends ListActivity
     			appInst.nodeSelection,
     			appInst.edits,
     			this.appdb.getTodos()));
+        getListView().setSelection( displayIndex );
 	}
 
     @Override
@@ -435,6 +447,7 @@ public class MobileOrgActivity extends ListActivity
             expandSelection(appInst.nodeSelection);
         }
         else {
+        	displayIndex = appInst.lastIndex();
             appInst.popSelection();
         }
     }

--- a/src/com/matburt/mobileorg/MobileOrgApplication.java
+++ b/src/com/matburt/mobileorg/MobileOrgApplication.java
@@ -41,6 +41,12 @@ public class MobileOrgApplication extends Application {
         if (this.nodeSelection != null && this.nodeSelection.size() > 0)
             this.nodeSelection.remove(nodeSelection.size()-1);
     }
+    
+    public int lastIndex() {
+        if (this.nodeSelection != null && this.nodeSelection.size() > 0)
+            return this.nodeSelection.get(nodeSelection.size()-1);
+    	return 0;
+    }
 
     public Node getSelectedNode()
     {


### PR DESCRIPTION
When going up in the node tree, focuses the list on the element you were coming from.
Example: You were right on the bottom of a list of nodes and pushed on one to look at it.
When you push the back button, you should see the item in the list you just visited. Until now, the list scrolled back all to the top.
