### PR TITLE
Fix Issue #80/Remove Hardcoding of SDCard Location

### DIFF
--- a/src/com/matburt/mobileorg/MobileOrgActivity.java
+++ b/src/com/matburt/mobileorg/MobileOrgActivity.java
@@ -16,6 +16,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
@@ -286,7 +287,8 @@ public class MobileOrgActivity extends ListActivity
             orgBasePath = fIndexFile.getParent() + "/";
         }
         else {
-            orgBasePath = "/sdcard/mobileorg/";
+            orgBasePath = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                          "/mobileorg/";
         }
 
         OrgFileParser ofp = new OrgFileParser(allOrgList,
@@ -366,7 +368,8 @@ public class MobileOrgActivity extends ListActivity
                     orgBasePath = fIndexFile.getParent() + "/";
                 }
                 else {
-                    orgBasePath = "/sdcard/mobileorg/";
+                    orgBasePath = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                                  "/mobileorg/";
                 }
 
                 byte[] rawData = OrgFileParser.getRawFileData(orgBasePath, thisNode.nodeName);
@@ -435,7 +438,8 @@ public class MobileOrgActivity extends ListActivity
                 orgBasePath = fIndexFile.getParent() + "/";
             }
             else {
-                orgBasePath = "/sdcard/mobileorg/";
+                orgBasePath = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                              "/mobileorg/";
             }
             String decryptedData = data.getStringExtra(Encryption.EXTRA_DECRYPTED_MESSAGE);
             OrgFileParser ofp = new OrgFileParser(appdb.getOrgFiles(),

--- a/src/com/matburt/mobileorg/MobileOrgSyncService.java
+++ b/src/com/matburt/mobileorg/MobileOrgSyncService.java
@@ -4,6 +4,7 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -166,7 +167,8 @@ public class MobileOrgSyncService extends Service implements SharedPreferences.O
             orgBasePath = fIndexFile.getParent() + "/";
         }
         else {
-            orgBasePath = "/sdcard/mobileorg/";
+            orgBasePath = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                          "/mobileorg/";
         }
 
         OrgFileParser ofp = new OrgFileParser(allOrgList,

--- a/src/com/matburt/mobileorg/MobileOrgWidget.java
+++ b/src/com/matburt/mobileorg/MobileOrgWidget.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.widget.RemoteViews;
@@ -62,7 +63,8 @@ public class MobileOrgWidget extends AppWidgetProvider {
                 orgBasePath = fIndexFile.getParent() + "/";
             }
             else {
-                orgBasePath = "/sdcard/mobileorg/";
+                orgBasePath = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                              "/mobileorg/";
             }
 
             OrgFileParser ofp = new OrgFileParser(allOrgList,

--- a/src/com/matburt/mobileorg/Parsing/OrgFileParser.java
+++ b/src/com/matburt/mobileorg/Parsing/OrgFileParser.java
@@ -1,6 +1,7 @@
 package com.matburt.mobileorg.Parsing;
 
 import android.content.ContentValues;
+import android.os.Environment;
 import android.util.Log;
 import com.matburt.mobileorg.MobileOrgDatabase;
 
@@ -32,7 +33,8 @@ public class OrgFileParser {
     MobileOrgDatabase appdb;
 	ArrayList<HashMap<String, Integer>> todos = null;
     public static final String LT = "MobileOrg";
-    public String orgDir = "/sdcard/mobileorg/";
+    public String orgDir = Environment.getExternalStorageDirectory() +
+                           "/mobileorg/";
 
     public OrgFileParser(HashMap<String, String> orgpaths,
                          String storageMode,
@@ -387,7 +389,8 @@ public class OrgFileParser {
                     || "sdcard".equals(this.storageMode)) {
                 String dirActual = "";
                 if (filename.equals("mobileorg.org")) {
-                    dirActual = "/sdcard/mobileorg/";
+                    dirActual = Environment.getExternalStorageDirectory().getAbsolutePath() +
+                                "/mobileorg/";
                 }
                 else {
                     dirActual = this.orgDir;


### PR DESCRIPTION
With SD Card sync mode selected, the synchronizer does not actually copy any files off the SD Card, even if "internal" storage mode is selected. When OrgFileParser attempts to read from the internal storage location, there is no file to open, resulting in a NullPointerException during synchronization.

Commit <tt>18da7ab5bb397f85822e40ba455bc98038f21e0d</tt> ensures that OrgFileParser will read the files directly from the SD Card whenever SD Card synchronization is selected, regardless of storage mode.

While I was playing with this, I found that the path to the SD Card was sometimes hard-coded as <em>/sdcard</em>. On my Xoom, the SD Card path is <em>/mnt/sdcard</em>, so I replaced the hard-coded references with calls to <tt>Environment.getExternalStorageDirectory()</tt>. That's commit <tt>7db3213e6897a311c2b622a9e5ccaa44916cfba6</tt>.
