### PR TITLE
Prompt before quitting EditActivity even if only payload changed.

### DIFF
--- a/src/com/matburt/mobileorg/Gui/Capture/EditActivity.java
+++ b/src/com/matburt/mobileorg/Gui/Capture/EditActivity.java
@@ -221,7 +221,8 @@ public class EditActivity extends FragmentActivity {
 	}
 	
 	private void doCancel() {
-		if(this.detailsFragment.hasEdits() == false) {
+		if(this.detailsFragment.hasEdits() == false &&
+                   this.payloadFragment.hasEdits() == false) {
 			setResult(RESULT_CANCELED);
 			finish();
 			return;

--- a/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
+++ b/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
@@ -16,6 +16,7 @@ public class EditPayloadFragment extends Fragment {
 	public static final String RESULT_STRING = "text";
     private EditText editDisplay;
 
+    private String orig_content;
     private String content;
 	private boolean enabled;
     
@@ -46,6 +47,10 @@ public class EditPayloadFragment extends Fragment {
     public String getText() {
     	return this.editDisplay.getText().toString();
     }
+
+	public boolean hasEdits() {
+            return (getText() != content);
+        }
         
 	@Override
 	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {


### PR DESCRIPTION
In EditActivity, pressing the back button now prompts if payload has changed, just as it did before if title, tags, etc have changed.
