### PR TITLE
Explicitly disable input length restriction for EditPayloadFragment.

### DIFF
--- a/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
+++ b/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
@@ -8,6 +8,7 @@ import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.text.InputFilter;
 
 import com.matburt.mobileorg.R;
 
@@ -39,6 +40,8 @@ public class EditPayloadFragment extends Fragment {
     }
 
     public void setText(String text) {
+        // work around Samsung's default limit of 9000 chars per text field
+        this.editDisplay.setFilters(new InputFilter[0]);
         this.editDisplay.setText(text);
         this.editDisplay.setSelection(text.length());
     }


### PR DESCRIPTION
Works around Samsung's odd default 9000 character restriction for TextViews.
One day I was in a meeting taking notes and input stopped when I hit 9000
chars. So I saved the note and made a new one, then later merged the two
on my desktop. When I synced that back to MobileOrg, I got a crash when I
tried to view the 12K note. This patch seems to fix the crash and also
the input restriction.

see also:

http://www.elmoensio.com/2012/03/11/gingerbread-9000-character-limit/

http://stackoverflow.com/a/3681475/589306
