### PR TITLE
Fix payload string comparison.

### DIFF
--- a/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
+++ b/src/com/matburt/mobileorg/Gui/Capture/EditPayloadFragment.java
@@ -52,7 +52,7 @@ public class EditPayloadFragment extends Fragment {
     }
 
 	public boolean hasEdits() {
-            return (getText() != content);
+            return (!getText().equals(content));
         }
         
 	@Override


### PR DESCRIPTION
Thought it seemed to work when I pushed it, but over the subsequent few days it became clear that the "do you really want to discard your edits" prompt was coming more often than necessary. 
