### PR TITLE
Fix greediness in parsing priority part of heading

### DIFF
--- a/src/com/matburt/mobileorg/Parsing/OrgFileParser.java
+++ b/src/com/matburt/mobileorg/Parsing/OrgFileParser.java
@@ -291,7 +291,7 @@ public class OrgFileParser {
     	if (OrgFileParser.titlePattern == null) {
     		StringBuffer pattern = new StringBuffer();
     		pattern.append("^\\s?(?:([A-Z]{2,}:?\\s+)\\s*)?"); 	// Todo
-    		pattern.append("(?:\\[\\#(.*)\\])?"); 				// Priority
+    		pattern.append("(?:\\[\\#([^]]+)\\])?"); 			// Priority
     		pattern.append("(.*?)"); 						// Title
     		pattern.append("\\s*(?::([^\\s]+):)?"); 		// Tags
     		pattern.append("(\\s*[!\\*])*"); 				// Habits


### PR DESCRIPTION
It caused problems when there was other closing brackets in the string, e.g. when there was a link.
