### PR TITLE
Part of regexp for extracting priority from heading was too greedy

### DIFF
--- a/src/com/matburt/mobileorg/provider/OrgNode.java
+++ b/src/com/matburt/mobileorg/provider/OrgNode.java
@@ -333,7 +333,7 @@ public class OrgNode {
     private static final int AFTER_GROUP = 7;
     
 	private static final Pattern titlePattern = Pattern
-			.compile("^\\s?(?:([A-Z]{2,}:?\\s+)\\s*)?" + "(?:\\[\\#(.*)\\])?" + // Priority
+			.compile("^\\s?(?:([A-Z]{2,}:?\\s+)\\s*)?" + "(?:\\[\\#([^]]+)\\])?" + // Priority
 					"(.*?)" + 											// Title
 					"\\s*(?::([^\\s]+):)?" + 							// Tags
 					"(\\s*[!\\*])*" + 									// Habits


### PR DESCRIPTION
It caused problems when there was other closing brackets in the string, e.g. when there was a link.

Second try - accommodated to changes in pr #268
