### PR TITLE
Set ActionBarSherlock target to API 15.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,4 @@ git submodule update
 android update project -s --path . --library libs/ActionBarSherlock/library/ -l libs/locale/
 
 android update lib-project --path libs/locale/
-android update lib-project --target 7 --path libs/ActionBarSherlock/library/
+android update lib-project --target 15 --path libs/ActionBarSherlock/library/


### PR DESCRIPTION
The current version of ActionBarSherlock was failing to build in my
environment, with errors like:

```
     [aapt] /Users/csw/src/mobileorg-android/libs/ActionBarSherlock/library/res/values-v14/abs__styles.xml:68: error: Error retrieving parent for item: No resource found that matches the given name 'android:Widget.Holo.ListView.DropDown'.
```

I was able to fix this by bumping the target API to v15, as mentioned in JakeWharton/ActionBarSherlock#517.
