### PR TITLE
Support for BUSY/AVAILABLE

### DIFF
--- a/src/com/matburt/mobileorg/Services/CalendarComptabilityWrappers.java
+++ b/src/com/matburt/mobileorg/Services/CalendarComptabilityWrappers.java
@@ -43,7 +43,7 @@ public class CalendarComptabilityWrappers {
 		public String _ID = "_id";
 		public String AVAILABILITY = "availability";
 		public Integer AVAILABILITY_BUSY = 0;
-                public Integer AVAILABILITY_FREE = 1;
+		public Integer AVAILABILITY_FREE = 1;
 		public Integer AVAILABILITY_TENTATIVE = 2;
 	};
 	

--- a/src/com/matburt/mobileorg/Services/CalendarSyncService.java
+++ b/src/com/matburt/mobileorg/Services/CalendarSyncService.java
@@ -32,9 +32,9 @@ public class CalendarSyncService extends Service implements
 	public final static String PULL = "pull";
 	public final static String PUSH = "push";
 	public final static String FILELIST = "filelist";
-        // The name of the org-property holding the availability status.
+	// The name of the org-property holding the availability status.
 	public final static String ORG_PROP_BUSY = "BUSY";
-    
+
 	private Context context;
 	private SharedPreferences sharedPreferences;
 	private ContentResolver resolver;
@@ -175,18 +175,18 @@ public class CalendarSyncService extends Service implements
 	private void tryToInsertNode(MultiMap<CalendarEntry> entries,
 			OrgNodeDate date, String filename, OrgNode node) {
 		CalendarEntry insertedEntry = entries.findValue(date.beginTime, date);
-                OrgNodePayload payload = node.getOrgNodePayload();
+		OrgNodePayload payload = node.getOrgNodePayload();
 
-                if (insertedEntry != null) {
+		if (insertedEntry != null) {
 			entries.remove(date.beginTime, insertedEntry);
 			unchanged++;
 		} else {
-                        calendarWrapper.insertEntry(date, node.getCleanedPayload(), filename, 
-                                                    payload.getProperty("LOCATION"), payload.getProperty(ORG_PROP_BUSY));
+			calendarWrapper.insertEntry(date, node.getCleanedPayload(), filename, 
+						payload.getProperty("LOCATION"), payload.getProperty(ORG_PROP_BUSY));
 			inserted++;
 		}
-	}        
-    
+	}
+
 	private boolean shouldInsertEntry(String todo, OrgNodeDate date) {
 		boolean isTodoActive = true;
 		if (TextUtils.isEmpty(todo) == false && allTodos.contains(todo))

--- a/src/com/matburt/mobileorg/Services/CalendarWrapper.java
+++ b/src/com/matburt/mobileorg/Services/CalendarWrapper.java
@@ -56,7 +56,7 @@ public class CalendarWrapper {
 				new String[] { CALENDAR_ORGANIZER + ":" + filename + "%" });
 	}
 	
-        public String insertEntry(OrgNodeDate date, String payload,
+	public String insertEntry(OrgNodeDate date, String payload,
 			String filename, String location, String busy) throws IllegalArgumentException {
 
 		if (this.calendarId == -1)
@@ -70,22 +70,22 @@ public class CalendarWrapper {
 				+ filename + "\n" + payload);
 		values.put(calendar.events.EVENT_LOCATION, location);
 
-                // If a busy state was given, send that info to calendar
-                if (busy != null) {
-                        // Trying to be reasonably tolerant with respect to the accepted values.
-                        if (busy.equals("nil") || busy.equals("0") ||
-                            busy.equals("no")  || busy.equals("available"))
-                                values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_FREE);
-                
-                        else if (busy.equals("t")   || busy.equals("1") ||
-                                 busy.equals("yes") || busy.equals("busy"))
-                                values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_BUSY);
-                    
-                        else if (busy.equals("2") || busy.equals("tentative") || busy.equals("maybe"))
-                                values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_TENTATIVE);
-                }
-                
-                // Sync with google will overwrite organizer :(
+		// If a busy state was given, send that info to calendar
+		if (busy != null) {
+			// Trying to be reasonably tolerant with respect to the accepted values.
+			if (busy.equals("nil") || busy.equals("0") ||
+			    busy.equals("no")  || busy.equals("available"))
+				values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_FREE);
+		
+			else if (busy.equals("t")   || busy.equals("1") ||
+				 busy.equals("yes") || busy.equals("busy"))
+				values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_BUSY);
+
+			else if (busy.equals("2") || busy.equals("tentative") || busy.equals("maybe"))
+				values.put(calendar.events.AVAILABILITY, calendar.events.AVAILABILITY_TENTATIVE);
+		}
+		
+		// Sync with google will overwrite organizer :(
 		// values.put(intEvents.ORGANIZER, embeddedNodeMetadata);
 
 		values.put(calendar.events.DTSTART, date.beginTime);


### PR DESCRIPTION
Support for defining availability from an org property called BUSY.

Strings supported (from the property) for each desired status are:
- Busy: t, 1, busy, yes.
- Available: nil, 0, available, no.
- Tentative: 2, tentative, maybe.
