### PR TITLE
Fix HACKING.md link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ And a dedicated Google Group for discussions and announcements:
 
 If you want to hack on the code:
 
-[HACKING.md](mobileorg-android/blob/master/HACKING.md)
+[HACKING.md](HACKING.md)


### PR DESCRIPTION
It's not working on https://github.com/matburt/mobileorg-android without this commit.
