### PR TITLE
Allow password field to be used as SSH private key passphrase.

### DIFF
--- a/src/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
+++ b/src/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
@@ -129,7 +129,10 @@ public class SSHSynchronizer implements SynchronizerInterface {
 		JSch jsch = new JSch();
 		try {
 			session = jsch.getSession(user, host, port);
-            if (!pubFile.equals("")) {
+            if (!pubFile.equals("") && !pass.equals("")) {
+                jsch.addIdentity(pubFile, pass);
+            }
+            else if (!pubFile.equals("")) {
                 jsch.addIdentity(pubFile);
             }
             else {


### PR DESCRIPTION
This is a partial fix for issue #348.  This is no less secure than storing a
user's SSH username and password, and it does offer a feature that is useful
when you don't want to have passwordless private keys sitting around on your
sd-card.
