### PR TITLE
Updated checksum file parser to support spaces in filenames

### DIFF
--- a/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFileParser.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFileParser.java
@@ -237,8 +237,8 @@ public class OrgFileParser {
 		for (String line : filecontents.split("[\\n\\r]+")) {
 			if (TextUtils.isEmpty(line))
 				continue;
-			String[] chksTuple = line.split("\\s+");
-			if(chksTuple.length >= 2)
+			String[] chksTuple = line.split("  ", 2);
+			if(chksTuple.length == 2)
 				checksums.put(chksTuple[1], chksTuple[0]);
 		}
 		return checksums;


### PR DESCRIPTION
This is a fix for https://github.com/matburt/mobileorg-android/issues/410, to allow the use of org filenames containing spaces.
