### PR TITLE
Fix convertLinks

### DIFF
--- a/MobileOrg/build.gradle
+++ b/MobileOrg/build.gradle
@@ -3,7 +3,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.github.jcandksolutions.gradle:android-unit-test:1.0.+'
     }
 }
 apply plugin: 'android'
@@ -11,15 +12,6 @@ apply plugin: 'android'
 repositories {
     mavenCentral()
 }
-
-dependencies {
-    compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:13.0.+'
-    compile 'com.jcraft:jsch:0.1.50'
-    compile project(':libraries:locale')
-    compile fileTree(dir: 'libs', include: '*.jar')
-}
-
 
 def getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
@@ -35,6 +27,7 @@ android {
     buildToolsVersion "19.0.1"
 
     defaultConfig {
+        packageName "com.matburt.mobileorg"
         minSdkVersion 9
         targetSdkVersion 17
         versionCode 913
@@ -68,5 +61,21 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
+}
+
+apply plugin: 'android-unit-test'
+
+dependencies {
+    compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
+    compile 'com.android.support:support-v4:13.0.+'
+    compile 'com.jcraft:jsch:0.1.50'
+    testCompile "junit:junit:4+"
+    testCompile 'org.robolectric:robolectric:2.3+'
+    compile project(':libraries:locale')
+    compile fileTree(dir: 'libs', include: '*.jar')
+
+    // These are only here to help IntelliJ find junit and robolectric classes
+    androidTestCompile "junit:junit:4+"
+    androidTestCompile 'org.robolectric:robolectric:2.3+'
 }
 

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/util/OrgNode2Html.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/util/OrgNode2Html.java
@@ -191,7 +191,7 @@ public class OrgNode2Html {
 		Matcher matcher = linkPattern.matcher(text);
 		text = matcher.replaceAll("<a href=\"$1\">$2</a>");
 		
-		Pattern urlPattern = Pattern.compile("[^(?:<a href=\"\\s*)](http[s]?://\\S+)");
+		Pattern urlPattern = Pattern.compile("(http[s]?://\\S+)");
 		matcher = urlPattern.matcher(text);
 		text = matcher.replaceAll("<a href=\"$1\">$1</a>");
 		

--- a/MobileOrg/src/test/java/com/matburt/mobileorg/util/OrgNode2HtmlTest.java
+++ b/MobileOrg/src/test/java/com/matburt/mobileorg/util/OrgNode2HtmlTest.java
@@ -1,0 +1,31 @@
+package com.matburt.mobileorg.util;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+public class OrgNode2HtmlTest {
+    private Activity activity;
+    private ContentResolver contentResolver;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = new Activity();
+        contentResolver = activity.getContentResolver();
+    }
+
+    @org.junit.Test
+    public void testUrlToHTML() throws Exception {
+        OrgNode2Html o = new OrgNode2Html(contentResolver, activity);
+        assertEquals("<html><body><font color='white'><pre>" +
+                     "<a href=\"http://mobileorg.ncogni.to/\">http://mobileorg.ncogni.to/</a>" +
+                     "</pre></font></body></html>",
+                o.toHTML("http://mobileorg.ncogni.to/"));
+    }
+}


### PR DESCRIPTION
I've added support for running unit-tests using `gradle test`, a test for `OrgNode2Html.convertLinks`, and finally fixed `convertLinks`; it wasn't correctly recognizing HTTP urls.

There are a couple of caveats, I'd be happy to address them if you think they're problematic, and you can point me in the right direction:
- I've never used Gradle before, so there's a chance this could be nicer. I followed https://github.com/JCAndKSolutions/android-unit-test in setting up unit-testing.
- There's no support for marking a directory as a test source, it needs to be done manually.
- I don't really understand what the original code I changed in `convertLinks` was supposed to do; I'm assuming the extra stuff in the regex was not intentional. If it was, now at least it's easy to test it.
