### PR TITLE
Implement org-mobile.el compatible de-/encryption

### DIFF
--- a/MobileOrg/build.gradle
+++ b/MobileOrg/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:1.1.+'
     }
 }
 apply plugin: 'android'
@@ -31,8 +31,8 @@ def getVersionName = { ->
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 9
@@ -55,7 +55,7 @@ android {
             signingConfig signingConfigs.matburt
         }
         donate {
-            packageNameSuffix ".donate"
+            applicationIdSuffix ".donate"
             signingConfig signingConfigs.matburt
         }
         debug {

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFile.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFile.java
@@ -158,11 +158,7 @@ public class OrgFile {
 		total += resolver.delete(OrgData.buildIdUri(nodeId), null, null);
 		return total;
 	}
-	
-	public boolean isEncrypted() {
-		return !PreferenceUtils.getEncryptionPass().isEmpty();
-	}
-	
+
 	public boolean generateEditsForFile() {
 		if(filename.equals(CAPTURE_FILE))
 			return false;

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFile.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/OrgData/OrgFile.java
@@ -2,6 +2,7 @@ package com.matburt.mobileorg.OrgData;
 
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 
@@ -9,6 +10,7 @@ import com.matburt.mobileorg.OrgData.OrgContract.Files;
 import com.matburt.mobileorg.OrgData.OrgContract.OrgData;
 import com.matburt.mobileorg.util.OrgFileNotFoundException;
 import com.matburt.mobileorg.util.OrgNodeNotFoundException;
+import com.matburt.mobileorg.util.PreferenceUtils;
 
 public class OrgFile {
 	public static final String CAPTURE_FILE = "mobileorg.org";
@@ -158,8 +160,7 @@ public class OrgFile {
 	}
 	
 	public boolean isEncrypted() {
-		return filename.endsWith(".gpg") || filename.endsWith(".pgp")
-				|| filename.endsWith(".enc") || filename.endsWith(".asc");
+		return !PreferenceUtils.getEncryptionPass().isEmpty();
 	}
 	
 	public boolean generateEditsForFile() {

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Services/SyncService.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Services/SyncService.java
@@ -71,6 +71,9 @@ public class SyncService extends Service implements
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
+		if (intent == null) {
+			return 0;
+		}
 		String action = intent.getStringExtra(ACTION);
 		if (action != null && action.equals(START_ALARM))
 			setAlarm();

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/DropboxSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/DropboxSynchronizer.java
@@ -1,10 +1,12 @@
 package com.matburt.mobileorg.Synchronizers;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import android.content.Context;
@@ -96,19 +98,25 @@ public class DropboxSynchronizer implements SynchronizerInterface {
         }
     }
 
+    @Override
 	public BufferedReader getRemoteFile(String filename) throws IOException {
+		return new BufferedReader(
+				new InputStreamReader(
+						getRemoteFileStream(filename)));
+	}
+
+    @Override
+	public InputStream getRemoteFileStream(String filename) throws IOException {
 		String filePath = this.remotePath + filename;
         try {
             DropboxInputStream is = dropboxApi.getFileStream(filePath, null);
-            BufferedReader fileReader = new BufferedReader(new InputStreamReader(is));
-            return fileReader;
+            return new BufferedInputStream(is);
         } catch (DropboxUnlinkedException e) {
             throw new IOException("Dropbox Authentication Failed, re-run setup wizard");
         } catch (DropboxException e) {
             throw new IOException("Fetching " + filename + ": " + e.toString());
         }
 	}
-
     
     /**
      * This handles authentication if the user's token & secret

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/DropboxSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/DropboxSynchronizer.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -80,7 +81,25 @@ public class DropboxSynchronizer implements SynchronizerInterface {
         BufferedWriter writer =  orgFile.getWriter();
         writer.write(contents);
         writer.close();
-    
+
+        putRemoteFile(filename, orgFile);
+    }
+
+    public void putRemoteFile(String filename, InputStream contents) throws IOException {
+        FileUtils orgFile = new FileUtils(filename, context);
+        final int bufSize = 8192;
+        int bytesRead = 0;
+        byte[] buffer = new byte[bufSize];
+        OutputStream os =  orgFile.getFileOutputStream();
+        while ( (bytesRead = contents.read(buffer, 0, bytesRead)) >= 0) {
+            os.write(buffer, 0, bytesRead);
+        }
+        os.close();
+
+        putRemoteFile(filename, orgFile);
+    }
+
+    private void putRemoteFile(String filename, FileUtils orgFile) throws IOException {
         File uploadFile = orgFile.getFile();
         FileInputStream fis = new FileInputStream(uploadFile);
         try {

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/NullSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/NullSynchronizer.java
@@ -12,9 +12,15 @@ public class NullSynchronizer implements SynchronizerInterface {
         return true;
     }
 
+    @Override
     public void putRemoteFile(String filename, String contents) {
     }
 
+    @Override
+    public void putRemoteFile(String filename, InputStream contents) {
+    }
+
+    @Override
     public BufferedReader getRemoteFile(String filename) {
         return null;
     }

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/NullSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/NullSynchronizer.java
@@ -1,6 +1,7 @@
 package com.matburt.mobileorg.Synchronizers;
 
 import java.io.BufferedReader;
+import java.io.InputStream;
 
 public class NullSynchronizer implements SynchronizerInterface {
 
@@ -18,8 +19,12 @@ public class NullSynchronizer implements SynchronizerInterface {
         return null;
     }
 
+	@Override
+	public InputStream getRemoteFileStream(String filename) {
+		return null;
+	}
 
-    @Override
+	@Override
 	public void postSynchronize() {
     }
 
@@ -27,4 +32,5 @@ public class NullSynchronizer implements SynchronizerInterface {
 	public boolean isConnectable() {
 		return true;
 	}
+
 }

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SDCardSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SDCardSynchronizer.java
@@ -7,8 +7,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import android.content.Context;
 import android.preference.PreferenceManager;
 
@@ -40,13 +40,21 @@ public class SDCardSynchronizer implements SynchronizerInterface {
 		writer.close();
 	}
 
+	@Override
 	public BufferedReader getRemoteFile(String filename) throws FileNotFoundException {
+		return new BufferedReader(
+				new InputStreamReader(
+						getRemoteFileStream(filename)));
+	}
+
+	@Override
+	public InputStream getRemoteFileStream(String filename) throws FileNotFoundException {
 		String filePath = this.remotePath + filename;
 		File file = new File(filePath);
 		FileInputStream fileIS = new FileInputStream(file);
-		return new BufferedReader(new InputStreamReader(fileIS));
-	}
 
+		return fileIS;
+	}
 
 	@Override
 	public void postSynchronize() {		

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SDCardSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SDCardSynchronizer.java
@@ -5,6 +5,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +32,7 @@ public class SDCardSynchronizer implements SynchronizerInterface {
         return true;
     }
 
+	@Override
 	public void putRemoteFile(String filename, String contents) throws IOException {
 		String outfilePath = this.remotePath + filename;
 		
@@ -38,6 +40,23 @@ public class SDCardSynchronizer implements SynchronizerInterface {
 		BufferedWriter writer = new BufferedWriter(new FileWriter(file, true));
 		writer.write(contents);
 		writer.close();
+	}
+
+	@Override
+	public void putRemoteFile(String filename, InputStream contents) throws IOException {
+		String outfilePath = this.remotePath + filename;
+
+		final int bufSize = 8192;
+		int bytesRead = 0;
+		byte[] buffer = new byte[bufSize];
+
+		File file = new File(outfilePath);
+		FileOutputStream fos = new FileOutputStream(file, false);
+
+		while ( (bytesRead = contents.read(buffer, 0, bufSize)) >= 0 ) {
+			fos.write(buffer, 0, bytesRead);
+		}
+		fos.close();
 	}
 
 	@Override

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
@@ -188,23 +188,30 @@ public class SSHSynchronizer implements SynchronizerInterface {
 	}
     }
 
+    @Override
     public void putRemoteFile(String filename, String contents) throws IOException {
+        ByteArrayInputStream bas = new ByteArrayInputStream(contents.getBytes());
+        putRemoteFile(filename, contents);
+	}
+
+    @Override
+    public void putRemoteFile(String filename, InputStream contents) throws IOException {
         try {
-	    session = getSession();
+            session = getSession();
 
             Channel channel = session.openChannel("sftp");
             channel.connect();
             ChannelSftp sftpChannel = (ChannelSftp) channel;
-            ByteArrayInputStream bas = new ByteArrayInputStream(contents.getBytes());
 
-            sftpChannel.put(bas, this.getRootUrl() + filename);
+            sftpChannel.put(contents, this.getRootUrl() + filename);
             sftpChannel.exit();
         } catch (Exception e) {
             Log.e("MobileOrg", "Exception in putRemoteFile: " + e.toString());
             throw new IOException(e);
         }
-	}
+    }
 
+    @Override
 	public BufferedReader getRemoteFile(String filename) throws IOException {
         StringBuilder contents = null;
         try {

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SSHSynchronizer.java
@@ -19,6 +19,7 @@ import android.util.Log;
 
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -26,15 +27,17 @@ import com.matburt.mobileorg.util.OrgUtils;
 
 public class SSHSynchronizer implements SynchronizerInterface {
 	private final String LT = "MobileOrg";
+        private final String knownHosts = "/sdcard/.known_hosts";
 
 	private String user;
 	private String host;
 	private String path;
-    private String pass;
-    private int port;
-    private String pubFile;
+        private String pass;
+        private int port;
+        private String pubFile;
 
 	private Session session;
+        private JSch jsch;
 
 	private SharedPreferences appSettings;
 
@@ -44,24 +47,26 @@ public class SSHSynchronizer implements SynchronizerInterface {
 		this.context = context;
 		this.appSettings = PreferenceManager
 				.getDefaultSharedPreferences(context.getApplicationContext());
-		path = appSettings.getString("scpPath", "");
-		user = appSettings.getString("scpUser", "");
-        host = appSettings.getString("scpHost", "");
-        pubFile = appSettings.getString("scpPubFile", "");
-        String tmpPort = appSettings.getString("scpPort", "");
-        if (tmpPort.equals("")) {
-            port = 22;
-        }
-        else {
-            port = Integer.parseInt(tmpPort);
-        }
-        pass = appSettings.getString("scpPass", "");
+	    path = appSettings.getString("scpPath", "");
+	    user = appSettings.getString("scpUser", "");
+	    host = appSettings.getString("scpHost", "");
+	    pubFile = appSettings.getString("scpPubFile", "");
+	    String tmpPort = appSettings.getString("scpPort", "");
+	    if (tmpPort.equals("")) {
+		port = 22;
+	    }
+	    else {
+		port = Integer.parseInt(tmpPort);
+	    }
+	    pass = appSettings.getString("scpPass", "");
 
-        try {
-            this.connect();
-        } catch (Exception e) {
-            Log.e("MobileOrg", "SSH Connection failed");
-        }
+	    try {
+		jsch = new JSch();
+		jsch.setKnownHosts(knownHosts);
+		this.connect();
+	    } catch (Exception e) {
+		Log.e("MobileOrg", "SSH Connection failed");
+	    }
 	}
 
     public String testConnection(String path, String user, String pass, String host, int port, String pubFile) {
@@ -85,6 +90,7 @@ public class SSHSynchronizer implements SynchronizerInterface {
             return "Missing configuration values";
         }
 
+	Log.d(LT, "Connecting: " + user + "@" + host + ":" + port);
         try {
             this.connect();
             BufferedReader r = this.getRemoteFile(this.getFileName());
@@ -130,10 +136,21 @@ public class SSHSynchronizer implements SynchronizerInterface {
 		return true;
 	}
 
-    public void connect() throws JSchException {
-		JSch jsch = new JSch();
-		try {
-			session = jsch.getSession(user, host, port);
+    private Session getSession() throws Exception {
+	// Avoid exception: "com.jcraft.jsch.JSchException: session is down"
+	// Following solution based on:
+	// https://stackoverflow.com/questions/16127200/jsch-how-to-keep-the-session-alive-and-up
+	// However, testChannel.exit() mentioned there does not exist.
+	try {
+	    ChannelExec testChannel = (ChannelExec) session.openChannel("exec");
+	    testChannel.setCommand("true");
+	    testChannel.connect();
+	    Log.d(LT, "SSH session usable");
+	    testChannel.disconnect();
+	} catch (Throwable t) {
+	    Log.d(LT, "Rebuilding broken session: "
+		  + user + "@" + host + ":" + port);
+	    session = jsch.getSession(user, host, port);
             if (!pubFile.equals("") && !pass.equals("")) {
                 jsch.addIdentity(pubFile, pass);
             }
@@ -144,20 +161,37 @@ public class SSHSynchronizer implements SynchronizerInterface {
                 session.setPassword(pass);
             }
 
-			java.util.Properties config = new java.util.Properties();
-			config.put("StrictHostKeyChecking", "no");
-			session.setConfig(config);
+	    java.util.Properties config = new java.util.Properties();
+	    // Beware!  "StrictHostKeyChecking no" is insecure.
+	    // With "StrictHostKeyChecking yes", lines in known_hosts must
+	    // start with the hostname or IP address in brackets, followed
+	    // by the port.  Otherwise, com.jcraft.jsch.Session.checkHost()
+	    // throws a NullPointerException.
+	    // [host.example.org]:22222 ssh-rsa ...
+	    config.put("StrictHostKeyChecking", "yes");
+	    // Generate hashed file via: ssh-keygen -H -f known_hosts
+	    config.put("HashKnownHosts", "yes");
+	    session.setConfig(config);
 
-			session.connect();
-			Log.d(LT, "SSH Connected");
-		} catch (JSchException e) {
-			Log.d(LT, e.getLocalizedMessage());
+	    session.connect();
+	}
+	return session;
+    }
+
+    public void connect() throws Exception {
+	try {
+	    session = getSession();
+	    Log.d(LT, "SSH Connected");
+	} catch (JSchException e) {
+	    Log.d(LT, e.getLocalizedMessage());
             throw e;
-		}
+	}
     }
 
     public void putRemoteFile(String filename, String contents) throws IOException {
         try {
+	    session = getSession();
+
             Channel channel = session.openChannel("sftp");
             channel.connect();
             ChannelSftp sftpChannel = (ChannelSftp) channel;

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/Synchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/Synchronizer.java
@@ -272,8 +272,9 @@ public class Synchronizer {
 			// Read the bytes
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
 			byte[] rawData = new byte[bufSize];
-			while ((isr.read(rawData, 0, bufSize)) >= 0) {
-				bos.write(rawData);
+			int bytesRead = 0;
+			while ((bytesRead = isr.read(rawData, 0, bufSize)) >= 0) {
+				bos.write(rawData, 0, bytesRead);
 			}
 			ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
 

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SynchronizerInterface.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SynchronizerInterface.java
@@ -2,6 +2,7 @@ package com.matburt.mobileorg.Synchronizers;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.cert.CertificateException;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -36,6 +37,15 @@ public interface SynchronizerInterface {
 	 */
 	public BufferedReader getRemoteFile(String filename)
         throws IOException, CertificateException, SSLHandshakeException;
+
+	/**
+	 * Returns a BufferedReader to the remote file.
+	 *
+	 * @param filename
+	 *            Name of the file, without path
+	 */
+	public InputStream getRemoteFileStream(String filename)
+		throws IOException, CertificateException, SSLHandshakeException;
 
 	/**
 	 * Use this to disconnect from any services and cleanup.

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SynchronizerInterface.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/SynchronizerInterface.java
@@ -30,6 +30,15 @@ public interface SynchronizerInterface {
         throws IOException;
 
 	/**
+	 * Replaces the file on the remote end with the given content.
+	 *
+	 * @param filename Name of the file, without path
+	 * @param contents Content of the new file
+	 */
+	public void putRemoteFile(String filename, InputStream contents)
+			throws IOException;
+
+	/**
 	 * Returns a BufferedReader to the remote file.
 	 * 
 	 * @param filename

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/UbuntuOneSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/UbuntuOneSynchronizer.java
@@ -8,7 +8,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import oauth.signpost.commonshttp.CommonsHttpOAuthConsumer;
 import oauth.signpost.exception.OAuthException;
@@ -211,6 +214,13 @@ private static final String BASE_TOKEN_NAME = "Ubuntu One @ MobileOrg:";
         }
         return null;
     }
+
+	@Override
+	public InputStream getRemoteFileStream(String filename) throws IOException,
+			CertificateException, SSLHandshakeException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 
     public ArrayList<String> getDirectoryList(String directory) {
         ArrayList<String> directories = new ArrayList<String>();
@@ -424,5 +434,6 @@ private static final String BASE_TOKEN_NAME = "Ubuntu One @ MobileOrg:";
 	public boolean isConnectable() {
 		return OrgUtils.isNetworkOnline(context);
 	}
+
 }
 		

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/UbuntuOneSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/UbuntuOneSynchronizer.java
@@ -134,6 +134,7 @@ private static final String BASE_TOKEN_NAME = "Ubuntu One @ MobileOrg:";
 		}
 	}
 
+    @Override
     public void putRemoteFile(String filename, String contents) throws IOException {
         try {
             buildConsumer();
@@ -180,6 +181,12 @@ private static final String BASE_TOKEN_NAME = "Ubuntu One @ MobileOrg:";
         }
     }
 
+    @Override
+    public void putRemoteFile(String filename, InputStream contents) throws IOException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
     public BufferedReader getRemoteFile(String filename) {
         try { 
             buildConsumer();

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/WebDAVSynchronizer.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Synchronizers/WebDAVSynchronizer.java
@@ -182,18 +182,22 @@ public class WebDAVSynchronizer implements SynchronizerInterface {
 		putUrlFile(urlActual, contents);
 	}
 
+	@Override
 	public BufferedReader getRemoteFile(String filename) throws IOException, CertificateException,
                                                                    SSLHandshakeException {
+
+		InputStream mainFile = getRemoteFileStream(filename);
+        return new BufferedReader(new InputStreamReader(mainFile));
+	}
+
+	@Override
+	public InputStream getRemoteFileStream(String filename) throws IOException,
+			CertificateException, SSLHandshakeException
+	{
 		String orgUrl = this.remotePath + filename;
         InputStream mainFile = null;
         try {
             mainFile = this.getUrlStream(orgUrl);
-
-            if (mainFile == null) {
-                return null;
-            } 
-
-            return new BufferedReader(new InputStreamReader(mainFile));
         }
         catch (CertificateException e) {
             Log.w("MobileOrg", "Conflicting certificate found: " + e.toString());
@@ -205,9 +209,11 @@ public class WebDAVSynchronizer implements SynchronizerInterface {
             handleChangedCertificate();
             throw e;
         }
-	}
 
-    /* See: http://stackoverflow.com/questions/1217141/self-signed-ssl-acceptance-android */
+        return mainFile;
+}
+
+	/* See: http://stackoverflow.com/questions/1217141/self-signed-ssl-acceptance-android */
     private void handleTrustRelationship(Context c) {
         try {
             HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier(){

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/util/FileUtils.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/util/FileUtils.java
@@ -10,6 +10,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
 import android.content.Context;
@@ -92,29 +93,38 @@ public class FileUtils {
 	
 	public BufferedWriter getWriter(boolean append) throws IOException {
 		String storageMode = getStorageMode();
-		BufferedWriter writer = null;
+		BufferedWriter writer = new BufferedWriter(
+				new OutputStreamWriter(getFileOutputStream(append)));
+
+		return writer;
+	}
+
+	public OutputStream getFileOutputStream() throws IOException {
+		return getFileOutputStream(false);
+	}
+
+	public OutputStream getFileOutputStream(boolean append) throws IOException {
+		String storageMode = getStorageMode();
+		FileOutputStream fs = null;
 
 		if (storageMode.equals("internal") || storageMode.equals("")) {
-			FileOutputStream fs;
 			String normalized = fileName.replace("/", "_");
-			if(append)
+			if(append) {
 				fs = context.openFileOutput(normalized, Context.MODE_APPEND);
-			else
+			} else {
 				fs = context.openFileOutput(normalized, Context.MODE_PRIVATE);
-			writer = new BufferedWriter(new OutputStreamWriter(fs));
-
+			}
 		} else if (storageMode.equals("sdcard")) {
 			File root = Environment.getExternalStorageDirectory();
 			File morgDir = new File(root, "mobileorg");
 			morgDir.mkdir();
 			if (morgDir.canWrite()) {
 				File orgFileCard = new File(morgDir, fileName);
-				FileWriter orgFWriter = new FileWriter(orgFileCard, append);
-				writer = new BufferedWriter(orgFWriter);
+				fs = new FileOutputStream(orgFileCard, append);
 			}
 		}
 
-		return writer;
+		return fs;
 	}
 
 	public File getFile() {

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/util/PreferenceUtils.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/util/PreferenceUtils.java
@@ -80,6 +80,10 @@ public class PreferenceUtils {
 		return appSettings.getString("encryptionPassword", "");
 	}
 
+	public static boolean isEncryptionEnabled() {
+		return !getEncryptionPass().isEmpty();
+	}
+
 	public static boolean useAdvancedCapturing() {
 		Context context = MobileOrgApplication.getContext();
 		return PreferenceManager.getDefaultSharedPreferences(context)

--- a/MobileOrg/src/main/java/com/matburt/mobileorg/util/PreferenceUtils.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/util/PreferenceUtils.java
@@ -74,6 +74,12 @@ public class PreferenceUtils {
 	    return appSettings.getString("theme", "Dark");
 	}
 
+	public static String getEncryptionPass() {
+		Context context = MobileOrgApplication.getContext();
+		SharedPreferences appSettings = PreferenceManager.getDefaultSharedPreferences(context);
+		return appSettings.getString("encryptionPassword", "");
+	}
+
 	public static boolean useAdvancedCapturing() {
 		Context context = MobileOrgApplication.getContext();
 		return PreferenceManager.getDefaultSharedPreferences(context)

--- a/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBECommon.java
+++ b/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBECommon.java
@@ -1,0 +1,39 @@
+package org.matzsoft.cipher;
+
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * @author dmatz
+ * Code: https://github.com/guardianproject/ChatSecureAndroid.git
+ */
+class OpenSSLPBECommon {
+
+protected static final int SALT_SIZE_BYTES = 8;
+protected static final String OPENSSL_HEADER_STRING = "Salted__";
+protected static final String OPENSSL_HEADER_ENCODE = "ASCII";
+
+protected static Cipher initializeCipher(char[] password, byte[] salt, int cipherMode,
+                                         final String algorithm, int iterationCount) throws NoSuchAlgorithmException, InvalidKeySpecException,
+        InvalidKeyException, NoSuchPaddingException, InvalidAlgorithmParameterException {
+
+    PBEKeySpec keySpec = new PBEKeySpec(password);
+    SecretKeyFactory factory = SecretKeyFactory.getInstance(algorithm);
+    SecretKey key = factory.generateSecret(keySpec);
+
+    Cipher cipher = Cipher.getInstance(algorithm);
+    cipher.init(cipherMode, key, new PBEParameterSpec(salt, iterationCount));
+
+    return cipher;
+}
+
+}

--- a/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBEInputStream.java
+++ b/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBEInputStream.java
@@ -1,0 +1,83 @@
+package org.matzsoft.cipher;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.crypto.Cipher;
+
+public class OpenSSLPBEInputStream extends InputStream {
+
+    private final static int READ_BLOCK_SIZE = 64 * 1024;
+
+    private final Cipher cipher;
+    private final InputStream inStream;
+    private final byte[] bufferCipher = new byte[READ_BLOCK_SIZE];
+
+    private byte[] bufferClear = null;
+
+    private int index = Integer.MAX_VALUE;
+    private int maxIndex = 0;
+
+    public OpenSSLPBEInputStream(final InputStream streamIn, String algIn, int iterationCount, char[] password)
+            throws IOException {
+        this.inStream = streamIn;
+        try {
+            byte[] salt = readSalt();
+            cipher = OpenSSLPBECommon.initializeCipher(password, salt, Cipher.DECRYPT_MODE, algIn, iterationCount);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return inStream.available();
+    }
+
+    @Override
+    public int read() throws IOException {
+
+        if (index > maxIndex) {
+            index = 0;
+            int read = inStream.read(bufferCipher);
+            if (read != -1) {
+                bufferClear = cipher.update(bufferCipher, 0, read);
+            }
+            if (read == -1 || bufferClear == null || bufferClear.length == 0) {
+                try {
+                    bufferClear = cipher.doFinal();
+                } catch (Exception e) {
+                    bufferClear = null;
+                }
+            }
+            if (bufferClear == null || bufferClear.length == 0) {
+                return -1;
+            }
+            maxIndex = bufferClear.length - 1;
+        }
+
+        if (bufferClear == null || bufferClear.length == 0) {
+            return -1;
+        }
+
+        return bufferClear[index++] & 0xff;
+
+    }
+
+    private byte[] readSalt() throws IOException {
+
+        byte[] headerBytes = new byte[OpenSSLPBECommon.OPENSSL_HEADER_STRING.length()];
+        inStream.read(headerBytes);
+        String headerString = new String(headerBytes, OpenSSLPBECommon.OPENSSL_HEADER_ENCODE);
+
+        if (!OpenSSLPBECommon.OPENSSL_HEADER_STRING.equals(headerString)) {
+            throw new IOException("unexpected file header " + headerString);
+        }
+
+        byte[] salt = new byte[OpenSSLPBECommon.SALT_SIZE_BYTES];
+        inStream.read(salt);
+
+        return salt;
+    }
+
+}

--- a/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBEOutputStream.java
+++ b/MobileOrg/src/main/java/org/matzsoft/cipher/OpenSSLPBEOutputStream.java
@@ -1,0 +1,70 @@
+package org.matzsoft.cipher;
+
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+
+import javax.crypto.Cipher;
+
+public class OpenSSLPBEOutputStream extends OutputStream {
+
+private static final int BUFFER_SIZE = 5 * 1024 * 1024;
+
+private final Cipher cipher;
+private final OutputStream outStream;
+private final byte[] buffer = new byte[BUFFER_SIZE];
+private int bufferIndex = 0;
+
+public OpenSSLPBEOutputStream(final OutputStream outputStream, String algIn, int iterationCount,
+                              char[] password) throws IOException {
+    outStream = outputStream;
+    try {
+        /* Create and use a random SALT for each instance of this output stream. */
+        byte[] salt = new byte[OpenSSLPBECommon.SALT_SIZE_BYTES];
+        new SecureRandom().nextBytes(salt);
+        cipher = OpenSSLPBECommon.initializeCipher(password, salt, Cipher.ENCRYPT_MODE, algIn, iterationCount);
+        /* Write header */
+        writeHeader(salt);
+    } catch (Exception e) {
+        throw new IOException(e);
+    }
+}
+
+@Override
+public void write(int b) throws IOException {
+    buffer[bufferIndex] = (byte) b;
+    bufferIndex++;
+    if (bufferIndex == BUFFER_SIZE) {
+        byte[] result = cipher.update(buffer, 0, bufferIndex);
+        outStream.write(result);
+        bufferIndex = 0;
+    }
+}
+
+@Override
+public void flush() throws IOException {
+    if (bufferIndex > 0) {
+        byte[] result;
+        try {
+            result = cipher.doFinal(buffer, 0, bufferIndex);
+            outStream.write(result);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+        bufferIndex = 0;
+    }
+}
+
+@Override
+public void close() throws IOException {
+    flush();
+    outStream.close();
+}
+
+private void writeHeader(byte[] salt) throws IOException {
+    outStream.write(OpenSSLPBECommon.OPENSSL_HEADER_STRING.getBytes(OpenSSLPBECommon.OPENSSL_HEADER_ENCODE));
+    outStream.write(salt);
+}
+
+}

--- a/MobileOrg/src/main/res/values/strings.xml
+++ b/MobileOrg/src/main/res/values/strings.xml
@@ -164,6 +164,9 @@
     <string name="preference_fontsize">Font size</string>
     <string name="preference_clear_db_dialog_title">Clear DB?</string>
     <string name="preference_clear_db_dialog_message">Are you sure want to clear DB?</string>
+    <string name="preference_encryption">Encryption</string>
+    <string name="preference_encryption_pass">Password</string>
+    <string name="preference_encryption_pass_summary">Password as used in Emacs org-mobile-encryption-password</string>
     <string name="preference_exclude_tags">Exclude tags inheritance</string>
     <string name="preference_exclude_tags_summary">Tags separated by \":\" to exclude from inheritance.</string>
     <string name="preference_combine_block_agenda_summary">Combines block agendas into one node, with separators. Needs resync of agenda file to take effect</string>
@@ -226,6 +229,7 @@
     <string name="key_calendarName">calendarName</string>
     <string name="key_calendarReminderInterval">calendarReminderInterval</string>
     <string name="key_theme">theme</string>
+    <string name="key_encryption_password">encryptionPassword</string>
     <string name="key_fontSize">fontSize</string>
     <string name="key_syncSource">syncSource</string>
     <string name="key_syncWifiOnly">syncWifiOnly</string>

--- a/MobileOrg/src/main/res/xml/preferences.xml
+++ b/MobileOrg/src/main/res/xml/preferences.xml
@@ -50,6 +50,15 @@
                     android:title="@string/preference_combine_block_agenda" />
             </PreferenceCategory>
         </PreferenceScreen>
+        <PreferenceScreen android:title="@string/preference_encryption">
+            <PreferenceCategory android:title="@string/preference_encryption">
+                <EditTextPreference
+                    android:key="@string/key_encryption_password"
+                    android:title="@string/preference_encryption_pass"
+                    android:summary="@string/preference_encryption_pass_summary"
+                    android:inputType="textPassword" />
+            </PreferenceCategory>
+        </PreferenceScreen>
         <PreferenceScreen android:title="@string/preference_interface" >
             <PreferenceCategory android:title="@string/preference_general" >
                 <ListPreference

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/libraries/locale/build.gradle
+++ b/libraries/locale/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url 'http://repo1.maven.org/maven2' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:1.1.+'
     }
 }
 
@@ -13,8 +13,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7


### PR DESCRIPTION
Similar to the MobileOrg iOS application an de- and encryption using aes-256-cbc cipher is implemented. No need to use APG, it uses cipher algorithm which are shipped with Android OS. To use encryption feature simply enter the password in the preferences.

This code uses also some handy classes which were taken from http://stackoverflow.com/questions/11783062/how-to-decrypt-an-encrypted-file-in-java-with-openssl-with-aes (https://github.com/guardianproject/ChatSecureAndroid.git).
In addition a change from chaos095 is included to activate StrictHostKeyChecking.
