### PR TITLE
Fix crash on app shutdown

### DIFF
--- a/MobileOrg/src/main/java/com/matburt/mobileorg/Services/SyncService.java
+++ b/MobileOrg/src/main/java/com/matburt/mobileorg/Services/SyncService.java
@@ -71,14 +71,16 @@ public class SyncService extends Service implements
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
-		String action = intent.getStringExtra(ACTION);
-		if (action != null && action.equals(START_ALARM))
-			setAlarm();
-		else if (action != null && action.equals(STOP_ALARM))
-			unsetAlarm();
-		else if(!this.syncRunning) {
-			this.syncRunning = true;
-			runSynchronizer();
+		if (intent != null) {
+			String action = intent.getStringExtra(ACTION);
+			if (action != null && action.equals(START_ALARM))
+				setAlarm();
+			else if (action != null && action.equals(STOP_ALARM))
+				unsetAlarm();
+			else if (!this.syncRunning) {
+				this.syncRunning = true;
+				runSynchronizer();
+			}
 		}
 		return 0;
 	}


### PR DESCRIPTION
On Android 5.1, the system displays a message saying "Unfortunately, MobileOrg has stopped." when the app shuts down. Logcat shows the following:

```
I/ActivityManager( 2395): Start proc 511:com.matburt.mobileorg/u0a153 for service com.matburt.mobileorg/.Services.SyncService
I/art     (  511): Late-enabling -Xcheck:jni
D/AndroidRuntime(  511): Shutting down VM
E/AndroidRuntime(  511): FATAL EXCEPTION: main
E/AndroidRuntime(  511): Process: com.matburt.mobileorg, PID: 511
E/AndroidRuntime(  511): java.lang.RuntimeException: Unable to start service com.matburt.mobileorg.Services.SyncService@1cbc2639 with null: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getStringExtra(java.lang.String)' on a null object reference
E/AndroidRuntime(  511):    at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2941)
E/AndroidRuntime(  511):    at android.app.ActivityThread.access$2100(ActivityThread.java:155)
E/AndroidRuntime(  511):    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1415)
E/AndroidRuntime(  511):    at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(  511):    at android.os.Looper.loop(Looper.java:135)
E/AndroidRuntime(  511):    at android.app.ActivityThread.main(ActivityThread.java:5343)
E/AndroidRuntime(  511):    at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(  511):    at java.lang.reflect.Method.invoke(Method.java:372)
E/AndroidRuntime(  511):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:905)
E/AndroidRuntime(  511):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:700)
E/AndroidRuntime(  511): Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getStringExtra(java.lang.String)' on a null object reference
E/AndroidRuntime(  511):    at com.matburt.mobileorg.Services.SyncService.onStartCommand(SyncService.java:74)
E/AndroidRuntime(  511):    at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:2924)
E/AndroidRuntime(  511):    ... 9 more
```

Fixed this by checking if `intent` is null before trying to get the message (`intent.getStringExtra(ACTION)`).
